### PR TITLE
Use the Composer autoloader when running tests

### DIFF
--- a/src/testing/templates/TestCaseMethod.tpl
+++ b/src/testing/templates/TestCaseMethod.tpl
@@ -14,8 +14,8 @@ set_include_path('{include_path}');
  * The code generated from this template runs in a new process and does not have
  * the autoloaders present.
  */
-if (is_readable({composerAutoload})) {
-    require_once({composerAutoload});
+if(is_readable({composerAutoload})) {
+	require_once({composerAutoload});
 }
 
 ob_start();

--- a/test/run-tests.php
+++ b/test/run-tests.php
@@ -2,8 +2,8 @@
 
 $composer_autoload = dirname(__FILE__).'/../vendor/autoload.php';
 
-if (is_readable($composer_autoload)) {
-    require($composer_autoload);
+if(is_readable($composer_autoload)) {
+	require($composer_autoload);
 }
 
 require('../src/testing.php');


### PR DESCRIPTION
When running the tests, Agavi does not use composers autoloading. On a machine that doesn't have PHPUnit installed globally, this leads do an immediate fatal error when the first PHPUnit class is needed.

A check for composers autoload.php and a `require` on that file needs to be added to the test scripts (e.g. in `test/run-tests.php`) and also in `src/testing/templates/TestCaseMethod.tpl` since the code generated from that template gets executed in a new process and also needs autoloading for the vendor libs.

**On TravisCI this issue does not appear because PHPUnit is installed globally on their VMs.** 
