### PR TITLE
Make AgaviXmlConfigParser::xinclude() use native sorting for glob

### DIFF
--- a/src/config/AgaviXmlConfigParser.class.php
+++ b/src/config/AgaviXmlConfigParser.class.php
@@ -502,9 +502,10 @@ class AgaviXmlConfigParser
 				$parts[0] = str_replace('\\', '/', AgaviToolkit::expandDirectives($parts[0]));
 				$attribute->nodeValue = implode('#', $parts);
 				if(strpos($parts[0], '*') !== false || strpos($parts[0], '{') !== false) {
-					$glob = glob($parts[0], GLOB_BRACE | GLOB_NOSORT);
+					$glob = glob($parts[0], GLOB_BRACE);
 					if($glob) {
 						$glob = array_unique($glob); // it could be that someone used /path/to/{Foo,*}/burp.xml so Foo would come before all others, that's why we need to remove duplicates as the * would match Foo again
+						sort($glob); // As glob()'s sorting may be unreliable, see e.g. https://glotpress.trac.wordpress.org/ticket/211
 						foreach($glob as $path) {
 							$new = $element->cloneNode(true);
 							$new->setAttribute('href', $path . (isset($parts[1]) ? '#' . $parts[1] : ''));

--- a/src/config/AgaviXmlConfigParser.class.php
+++ b/src/config/AgaviXmlConfigParser.class.php
@@ -505,7 +505,6 @@ class AgaviXmlConfigParser
 					$glob = glob($parts[0], GLOB_BRACE);
 					if($glob) {
 						$glob = array_unique($glob); // it could be that someone used /path/to/{Foo,*}/burp.xml so Foo would come before all others, that's why we need to remove duplicates as the * would match Foo again
-						sort($glob); // As glob()'s sorting may be unreliable, see e.g. https://glotpress.trac.wordpress.org/ticket/211
 						foreach($glob as $path) {
 							$new = $element->cloneNode(true);
 							$new->setAttribute('href', $path . (isset($parts[1]) ? '#' . $parts[1] : ''));


### PR DESCRIPTION
Using XIncludes with globbing may result in different sorting on different systems right now. Adding an explicit `sort()` call makes the order of the included files reliable.