### PR TITLE
Support parameter names with multiple dashes at the beginning in AgaviConsoleRequest

### DIFF
--- a/src/request/AgaviConsoleRequest.class.php
+++ b/src/request/AgaviConsoleRequest.class.php
@@ -108,7 +108,7 @@ class AgaviConsoleRequest extends AgaviRequest
 		$rd = $this->getRequestData();
 		
 		foreach($parameters as $name => $value) {
-			$rd->setParameter(substr($name, 1), $value);
+			$rd->setParameter(ltrim($name, '-'), $value);
 		}
 		
 		$this->input = implode(' ', $input);


### PR DESCRIPTION
Right now only `-name value` is supported, this change makes `--name value` (and even `-------name value`) work as well.
