### PR TITLE
Make cookie encoding configurable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@ ADD: Allow array syntax for slot names (#1110) (David)
 ADD: Add support for custom filesystem layouts for modules to the project configuration system (#874) (Noah)
 ADD: Response attributes (#1062) (David, TANAKA Koichi)
 ADD: Add AgaviJsonValidator (#1566) (Thomas Bachem)
+ADD: Add "cookie_encoding_callback" parameter to AgaviWebResponse (#1482) (Thomas Bachem)
 
 CHG: Make AgaviXmlConfigParser::xinclude() use native sorting for glob (#1476) (Thomas Bachem)
 CHG: Improve AgaviFormPopulationFilter's "log_parse_errors" setting to handle severities (#1481) (Thomas Bachem)

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
 		"phing/phing": "~2.6.1"
 	},
 	"require-dev": {
-		"phpunit/phpunit": ">=3.7 <=4.8.10"
+		"phpunit/phpunit": ">=3.7 <=4.8.10",
+		"ext-xdebug": ">=2.1"
 	},
 	"suggest": {
 		"phpunit/phpunit": "Install phpunit if you want to run your tests",

--- a/samples/app/config/factories.xml
+++ b/samples/app/config/factories.xml
@@ -19,7 +19,12 @@
 		
 		<request class="AgaviWebRequest" />
 		
-		<response class="AgaviWebResponse" />
+		<response class="AgaviWebResponse">
+			<!-- Encode cookies with rawurlencode() instead of urlencode() to make them compliant with RFC 6265. -->
+			<!-- We sadly cannot change the default encoding of cookies as it would be a breaking change for -->
+			<!-- existing Agavi projects, but recommend to set this setting to "rawurlencode" for new projects. -->
+			<ae:parameter name="cookie_encode_callback">rawurlencode</ae:parameter>
+		</response>
 		
 		<routing class="AgaviWebRouting" />
 		

--- a/src/build/templates/app/config/factories.xml.tmpl
+++ b/src/build/templates/app/config/factories.xml.tmpl
@@ -19,7 +19,10 @@
 		
 		<request class="AgaviWebRequest" />
 		
-		<response class="AgaviWebResponse" />
+		<response class="AgaviWebResponse">
+			<!-- Encode cookies with rawurlencode() instead of urlencode() to make them compliant with RFC 6265 -->
+			<ae:parameter name="cookie_encode_callback">rawurlencode</ae:parameter>
+		</response>
 		
 		<routing class="AgaviWebRouting" />
 		


### PR DESCRIPTION
**Add `cookie_encode_callback` parameter to AgaviWebResponse and `$encodeCallback` argument to setCookie()**
For historical reasons, PHP's `setcookie()` encodes cookies with `urlencode()`, which is not compliant with RFC 6265 as it encodes spaces as a "+" sign instead of "%20". This makes most client-side Javascript cookie libraries decode it not as a space but as an actual plus sign. We sadly cannot change the default encoding of cookies as it would be a breaking change, but can use `setrawcookie()` and introduce a setting `cookie_encode_callback` instead, which defaults to `urlencode` but we recommend to set to `rawurlencode` for new projects. On top of that, users can provide a custom encoding function for values on a per-cookie basis if needed..