### PR TITLE
Add validation depend tokens to validation report

### DIFF
--- a/src/validator/AgaviDependencyManager.class.php
+++ b/src/validator/AgaviDependencyManager.class.php
@@ -74,7 +74,7 @@ class AgaviDependencyManager
 		
 		return true;
 	}
-
+	
 	/**
 	 * Puts a list of tokens into the dependency cache.
 	 * 
@@ -91,5 +91,19 @@ class AgaviDependencyManager
 			$base->setValueByChildPath($token, $this->depData, true);
 		}
 	}
+	
+	/**
+	 * Returns the list of provided tokens from the dependency cache.
+	 *
+	 * @return     array Provided tokens from the dependency cache.
+	 *
+	 * @author     Steffen Gransow <agavi@mivesto.de>
+	 * @since      1.0.8
+	 */
+	public function getDependTokens()
+	{
+		return $this->depData;
+	}
 }
+
 ?>

--- a/src/validator/AgaviValidationManager.class.php
+++ b/src/validator/AgaviValidationManager.class.php
@@ -285,6 +285,7 @@ class AgaviValidationManager extends AgaviParameterHolder implements AgaviIValid
 			}
 		}
 		$this->report->setResult($result);
+		$this->report->setDependTokens($this->getDependencyManager()->getDependTokens());
 
 		$ma = $req->getParameter('module_accessor');
 		$aa = $req->getParameter('action_accessor');

--- a/src/validator/AgaviValidationReport.class.php
+++ b/src/validator/AgaviValidationReport.class.php
@@ -45,6 +45,11 @@ class AgaviValidationReport implements AgaviIValidationReportQuery
 	protected $incidents = array();
 	
 	/**
+	 * @var        array The depend tokens provided by the validation run.
+	 */
+	protected $providedDependTokens = array();
+	
+	/**
 	 * Retrieves the highest validation result code in this report.
 	 *
 	 * @return     int An AgaviValidator::* severity constant, or null if there is
@@ -130,6 +135,47 @@ class AgaviValidationReport implements AgaviIValidationReportQuery
 			$incidents = array_merge($incidents, $validatorIncidents);
 		}
 		return $incidents;
+	}
+	
+	/**
+	 * Sets dependency tokens provided by executed validators onto the result.
+	 *
+	 * @param      array The depend tokens of the AgaviDependencyManager.
+	 *
+	 * @author     Steffen Gransow <agavi@mivesto.de>
+	 * @since      1.0.8
+	 */
+	public function setDependTokens(array $dependTokens = array())
+	{
+		$this->providedDependTokens = $dependTokens;
+	}
+	
+	/**
+	 * Check whether the given depend token was provided by the validation run.
+	 *
+	 * @param      string Name of depend token suspected to have been provided.
+	 *
+	 * @return     bool True if depend token was provided.
+	 *
+	 * @author     Steffen Gransow <agavi@mivesto.de>
+	 * @since      1.0.8
+	 */
+	public function hasDependToken($token)
+	{
+		return $this->createQuery()->hasDependToken($token);
+	}
+	
+	/**
+	 * Check whether the given depend token was provided by the validation run.
+	 *
+	 * @return     array All provided depend tokens.
+	 *
+	 * @author     Steffen Gransow <agavi@mivesto.de>
+	 * @since      1.0.8
+	 */
+	public function getDependTokens()
+	{
+		return $this->providedDependTokens;
 	}
 	
 	/**

--- a/src/validator/AgaviValidationReportQuery.class.php
+++ b/src/validator/AgaviValidationReportQuery.class.php
@@ -259,6 +259,34 @@ class AgaviValidationReportQuery implements AgaviIValidationReportQuery
 	}
 	
 	/**
+	 * Retrieves all depend tokens provided by the validation run.
+	 *
+	 * @return     array All depend tokens provided by the validation run.
+	 *
+	 * @author     Steffen Gransow <agavi@mivesto.de>
+	 * @since      1.0.8
+	 */
+	public function getDependTokens()
+	{
+		return $this->report->getDependTokens();
+	}
+	
+	/**
+	 * Check whether the given depend token was provided by the validation run.
+	 *
+	 * @param      string Name of depend token suspected to have been provided.
+	 *
+	 * @return     bool True if depend token was provided.
+	 *
+	 * @author     Steffen Gransow <agavi@mivesto.de>
+	 * @since      1.0.8
+	 */
+	public function hasDependToken($name)
+	{
+		return array_key_exists($name, $this->report->getDependTokens());
+	}
+	
+	/**
 	 * Retrieves all AgaviValidationError objects which match the currently
 	 * defined filter rules.
 	 * 


### PR DESCRIPTION
The tokens provided by validators for other validators to depend on are not accessible later on in the request. For some use cases the actual tokens may be nice to have as it saves developers from having to export custom request parameters for later usage in actions etc.

This changeset makes the depend tokens available via the validation report and the validation report query. The change should be backwards compatible and does not change how the validation works at the moment.

The tokens are made available "as is" without the possibility to query for tokens by their `base` argument path (that is, ```contact[street_set]``` might by returned).

Example usage in a custom validator:

```php
class CounterValidator extends AgaviValidator {
    const COUNT_THRESHOLD = 'some_threshold_is_reached_or_so';
    protected function validate()
    {
        // check some constraints and add some token if necessary
        $this->getDependencyManager()->addDependTokens(
            array(self::COUNT_THRESHOLD),
            $this->curBase
        );
        return true;
    }

    protected function checkAllArgumentsSet($throwError = true)
    {
        return true; // always execute validator despite argument missing
    }
}
```

and then check for possible tokens later on in actions or views like this:

```php
$validation_report = $this->getContainer()->getValidationManager()->getReport();
$this->setAttribute(
    'show_captcha',
    $validation_report->hasDependToken(CounterValidator::COUNT_THRESHOLD)
);
```

The tokens may of course be provided via the [normal usage in the `validators.xml` files](http://mivesto.de/agavi/agavi-faq.html#validation_4):

```xml
<validator ... required="false" provides="street_set">
    <arguments base="contact">
        <argument>Street</argument>
    </arguments>
</validator>

<validator ... required="true" depends="contact[street_set]">
    <arguments base="contact">
        <argument>Zip</argument>
    </arguments>
</validator>
```

```php
$validation_report = $this->getContainer()->getValidationManager()->getReport();
if ($validation_report->hasDependToken('contact[street_set]')) {
    // …
}
```

No tests were added as the PR is against the 1.0 branch where no validation dependency management or validation manager tests exist yet. Master had failing tests and the `test2` folder is not migrated yet.

Any comments are welcome.