### PR TITLE
AgaviTemplateLayer possibly overwrites given parameters with defaults

### DIFF
--- a/src/view/AgaviTemplateLayer.class.php
+++ b/src/view/AgaviTemplateLayer.class.php
@@ -54,10 +54,10 @@ abstract class AgaviTemplateLayer extends AgaviParameterHolder
 	 */
 	public function __construct(array $parameters = array())
 	{
-		parent::__construct(array_merge($parameters, array(
+		parent::__construct(array_merge(array(
 			'module' => null,
 			'template' => null,
-		)));
+		), $parameters));
 	}
 	
 	/**


### PR DESCRIPTION
The default merging of parameters in the `AgaviTemplateLayer` constructor is broken. Setting `module` and/or `template` values via constructor always leads to those parameters being `null`.
