### PR TITLE
Added missing php tags to agavi_wrapped.php

### DIFF
--- a/src/build/agavi/script/agavi_wrapped.php
+++ b/src/build/agavi/script/agavi_wrapped.php
@@ -1,3 +1,4 @@
+<?php
 // +---------------------------------------------------------------------------+
 // | This file is part of the Agavi package.                                   |
 // | Copyright (c) 2005-2011 the Agavi Project.                                |


### PR DESCRIPTION
The php tag was missing so when installing via composer and running agavi.bat on windows the file content was displayed
