### PR TITLE
Allow errors in validator_definition elements

### DIFF
--- a/src/config/AgaviValidatorConfigHandler.class.php
+++ b/src/config/AgaviValidatorConfigHandler.class.php
@@ -70,10 +70,11 @@ class AgaviValidatorConfigHandler extends AgaviXmlConfigHandler
 				foreach($cfg->get('validator_definitions') as $def) {
 					$name = $def->getAttribute('name');
 					if(!isset($this->classMap[$name])) {
-						$this->classMap[$name] = array('class' => $def->getAttribute('class'), 'parameters' => array());
+						$this->classMap[$name] = array('class' => $def->getAttribute('class'), 'parameters' => array(), 'errors' => array());
 					}
 					$this->classMap[$name]['class'] = $def->getAttribute('class',$this->classMap[$name]['class']);
 					$this->classMap[$name]['parameters'] = $def->getAgaviParameters($this->classMap[$name]['parameters']);
+					$this->classMap[$name]['errors'] = $this->getAgaviErrors($def, $this->classMap[$name]['errors']);
 				}
 			}
 			
@@ -122,20 +123,19 @@ class AgaviValidatorConfigHandler extends AgaviXmlConfigHandler
 			if(!class_exists($class)) {
 				throw new AgaviValidatorException('unknown validator found: ' . $class);
 			}
-			$this->classMap[$class] = array('class' => $class, 'parameters' => array());
+			$this->classMap[$class] = array('class' => $class, 'parameters' => array(), 'errors' => array());
 		} else {
 			$class = $this->classMap[$validator->getAttribute('class')]['class'];
 		}
-
+		
 		// setting up parameters
 		$parameters = array(
 			'severity' => $validator->getAttribute('severity', $stdSeverity),
 			'required' => $stdRequired,
 		);
-
+		
 		$arguments = array();
-		$errors = array();
-
+		
 		$stdMethod = $validator->getAttribute('method', $stdMethod);
 		$stdSeverity = $parameters['severity'];
 		if($validator->hasAttribute('name')) {
@@ -144,7 +144,7 @@ class AgaviValidatorConfigHandler extends AgaviXmlConfigHandler
 			$name = AgaviToolkit::uniqid();
 			$validator->setAttribute('name', $name);
 		}
-
+		
 		$parameters = array_merge($this->classMap[$validator->getAttribute('class')]['parameters'], $parameters);
 		$parameters = array_merge($parameters, $validator->getAttributes());
 		$parameters = $validator->getAgaviParameters($parameters);
@@ -168,6 +168,7 @@ class AgaviValidatorConfigHandler extends AgaviXmlConfigHandler
 			}
 		}
 		
+		$errors = $this->classMap[$validator->getAttribute('class')]['errors'];
 		foreach($validator->get('errors') as $error) {
 			if($error->hasAttribute('for')) {
 				$errors[$error->getAttribute('for')] = $error->getValue();
@@ -179,12 +180,12 @@ class AgaviValidatorConfigHandler extends AgaviXmlConfigHandler
 		if($validator->hasAttribute('required')) {
 			$stdRequired = $parameters['required'] = AgaviToolkit::literalize($validator->getAttribute('required'));
 		}
-
+		
 		$methods = array('');
 		if(trim($stdMethod)) {
 			$methods = preg_split('/[\s]+/', $stdMethod);
 		}
-
+		
 		foreach($methods as $method) {
 			$code[$method][$name] = implode("\n", array(
 				sprintf(
@@ -252,6 +253,38 @@ class AgaviValidatorConfigHandler extends AgaviXmlConfigHandler
 		}
 		
 		return $code;
+	}
+	
+	/**
+	 * Retrieve all of the Agavi error elements associated with this
+	 * element.
+	 *
+	 * @param      AgaviXmlConfigDomElement The value holder of this validator.
+	 * @param      array                    An array of existing errors.
+	 *
+	 * @return     array The complete array of errors.
+	 *
+	 * @author     Jan Schütze <JanS@DracoBlue.de>
+	 * @author     Steffen Gransow <agavi@mivesto.de>
+	 *
+	 * @since      1.0.8
+	 */
+	public function getAgaviErrors(AgaviXmlConfigDomElement $node, array $existing = array())
+	{
+		$result = $existing;
+		
+		$elements = $node->get('errors', self::XML_NAMESPACE);
+		
+		foreach($elements as $element) {
+			$key = '';
+			if($element->hasAttribute('for')) {
+				$key = $element->getAttribute('for');
+			}
+			
+			$result[$key] = $element->getValue();
+		}
+		
+		return $result;
 	}
 }
 

--- a/src/config/xsd/parts/validators.xsd
+++ b/src/config/xsd/parts/validators.xsd
@@ -118,8 +118,10 @@
 	</xs:group>
 
 	<xs:complexType name="validator_definition">
-		<xs:sequence>
+		<xs:sequence maxOccurs="unbounded">
 			<xs:group ref="envelope_1_1:parameters" />
+			<xs:group ref="errors"
+			          minOccurs="0" />
 		</xs:sequence>
 		<xs:attribute name="name" type="types_1_0:non_empty_string" use="required" />
 		<xs:attribute name="class" type="types_1_0:php_class" use="required" />


### PR DESCRIPTION
This change allows `errors` in ```validator_definition``` elements in ```validators.xml``` files. This means validator definitions can define default error messages instead of providing those on each concrete validator defined later on (based on the validator definition).

Example from e.g. ```app/config/validators.xml``` file:
```xml
        <validator_definitions>
                
            <validator_definition name="custom" class="SomeCustomValidator">
                <ae:parameters>
                    <ae:parameter name="required">true</ae:parameter>
                </ae:parameters>                
                <errors>
                    <error>This is some default error that wasn't possible before this patch.</error>
                    <error for="special">Some very special error message.</error>
                </errors>
            </validator_definition>
            
        </validator_definitions>
```

This changeset is adapted from a version @dracoblue and me did some time ago. There are no tests as I would need some hints/help on that. Comments welcome.