### PR TITLE
Use default translation domain on validation error messages

### DIFF
--- a/src/validator/AgaviValidator.class.php
+++ b/src/validator/AgaviValidator.class.php
@@ -489,11 +489,7 @@ abstract class AgaviValidator extends AgaviParameterHolder
 			$this->affectedArguments = $affectedArguments;
 		}
 
-		$error = $this->getErrorMessage($index);
-
-		if($this->hasParameter('translation_domain')) {
-			$error = $this->getContext()->getTranslationManager()->_($error, $this->getParameter('translation_domain'));
-		}
+		$error = $this->getContext()->getTranslationManager()->_($this->getErrorMessage($index), $this->getParameter('translation_domain'));
 
 		if(!$this->incident) {
 			$this->incident = new AgaviValidationIncident($this, self::mapErrorCode($this->getParameter('severity', 'error')));


### PR DESCRIPTION
The error message of a Validator is only translated when there is a `translation_domain` set on the validator. This seems unnecessary as the `_` method of the `AgaviTranslationManager` handles this fine anyways. As the `getParameter` returns `null` the `_` method will use the default translation domain on the error message given.
