### PR TITLE
fixed required phing version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
 		"ext-spl": "*",
 		"ext-reflection": "*",
 		"ext-pcre": "*",
-
-		"phing/phing": "~2.4"
+		"phing/phing": "~2.6.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~3.5"


### PR DESCRIPTION
fixed require tilde-operator usage to install fing below version 2.7 as described here

https://getcomposer.org/doc/01-basic-usage.md#next-significant-release-tilde-operator-

https://github.com/agavi/agavi/issues/1493
