### PR TITLE
Add "forms_xpath" setting to FPF

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@ ADD: Allow array syntax for slot names (#1110) (David)
 ADD: Add support for custom filesystem layouts for modules to the project configuration system (#874) (Noah)
 ADD: Response attributes (#1062) (David, TANAKA Koichi)
 ADD: Add AgaviJsonValidator (#1566) (Thomas Bachem)
+ADD: Add "forms_xpath" setting to AgaviFormPopulationFilter (#1527) (Thomas Bachem)
 
 CHG: Make AgaviXmlConfigParser::xinclude() use native sorting for glob (#1476) (Thomas Bachem)
 CHG: Improve AgaviFormPopulationFilter's "log_parse_errors" setting to handle severities (#1481) (Thomas Bachem)

--- a/test/tests/unit/filter/AgaviFormPopulationFilterTest.php
+++ b/test/tests/unit/filter/AgaviFormPopulationFilterTest.php
@@ -112,6 +112,23 @@ class AgaviFormPopulationFilterTest extends AgaviUnitTestCase
 		$this->assertEquals('ul', $xpath->query('//form/*[1]')->item(0)->nodeName);
 	}
 	
+	public function testFormsXpathSetting()
+	{
+		$html = '<!DOCTYPE html><html><body><input type="text" name="foo"></body></html>';
+		$parameters = array(
+			'foo' => 'bar',
+		);
+		
+		$config = array(
+			'forms_xpath' => '//${htmlnsPrefix}body',
+		);
+		
+		$content = $this->executeFormPopulationFilter($html, $parameters, null, $config);
+		$xpath = $this->loadXpath($content);
+		
+		$this->assertEquals(1, $xpath->query('//input[@value="bar"]')->length);
+	}
+	
 	/**
 	 * @param string $content
 	 * @param \AgaviRequestDataHolder|array $parameters


### PR DESCRIPTION
By default, FPF does only work on inputs in ``<form>`` elements. This setting makes the query that is used to find "form" (container) elements configurable, which may e.g. come handy if FPF is executed on a partial document fragment that doesn’t contain the ``<form>`` element.