### PR TITLE
Remove extra quotations from batch file

### DIFF
--- a/bin/agavi-dist
+++ b/bin/agavi-dist
@@ -8,7 +8,7 @@
 
 # Set this to the path to the Agavi installation's source directory. This is
 # the directory that contains the `agavi.php' file.
-AGAVI_SOURCE_DIRECTORY="@PEAR-DIR@/agavi"
+AGAVI_SOURCE_DIRECTORY=@PEAR-DIR@/agavi
 
 # Set this to the path to a PHP binary.
 PHP_EXECUTABLE=$( which php )

--- a/bin/agavi.bat-dist
+++ b/bin/agavi.bat-dist
@@ -8,9 +8,9 @@
 
 :: Set this to the path to the Agavi installation's source directory. This is
 :: the directory that contains the `agavi.php' file.
-SET AGAVI_SOURCE_DIRECTORY="@PEAR-DIR@/agavi"
+SET AGAVI_SOURCE_DIRECTORY=@PEAR-DIR@/agavi
 
 :: Set this to the path to a PHP binary.
-SET PHP_EXECUTABLE="@PHP-BIN@"
+SET PHP_EXECUTABLE=@PHP-BIN@
 
 "%PHP_EXECUTABLE%" -d memory_limit=4294967295 -f "%AGAVI_SOURCE_DIRECTORY%/build/agavi/script/agavi.php" -- --agavi-source-directory "%AGAVI_SOURCE_DIRECTORY%" %*


### PR DESCRIPTION
The command

``` bat
SET AGAVI_SOURCE_DIRECTORY="@PEAR-DIR@/agavi"
```

actually includes the quotations in the value. This is not desired, and
it resulted in an error when I attempted to run agavi for the first
time.

The error was:

```
'""D:\Programs\PHP' is not recognized as an internal or external
command, operable program or batch file.
```
