### PR TITLE
Make sure that getContents() returns request payload

### DIFF
--- a/src/request/AgaviUploadedFile.class.php
+++ b/src/request/AgaviUploadedFile.class.php
@@ -410,9 +410,9 @@ class AgaviUploadedFile implements ArrayAccess
 		return
 			$this->hasBufferedContents()
 				? $this->contents
-				: $this->hasOpenStream()
+				: ($this->hasOpenStream()
 					? stream_get_contents($this->getStream(), -1, 0)
-					: file_get_contents($this->getTmpName())
+					: file_get_contents($this->getTmpName()))
 		;
 	}
 	


### PR DESCRIPTION
I had to put those extra parenthesis so $rd->removeFile('put_file')->getContents(); and $rd->removeFile('post_file')->getContents(); would return the request payload in my RESTWebRequest class: http://pastebin.com/uXrAiGxB . Otherwise it would return an empty string.