### PR TITLE
Fixed path encoding in AgaviXmlConfigParser::xinclude()

### DIFF
--- a/src/config/AgaviXmlConfigParser.class.php
+++ b/src/config/AgaviXmlConfigParser.class.php
@@ -494,7 +494,7 @@ class AgaviXmlConfigParser
 	 */
 	public static function xinclude(AgaviXmlConfigDomDocument $document)
 	{
-		// replace %lala% directives in XInclude href attributes
+		// expand directives, resolve globs and encode paths in XInclude href attributes
 		$elements = $document->getElementsByTagNameNS(self::NAMESPACE_XINCLUDE_2001, 'include');
 		$length = $elements->length;
 		// we can't foreach() over the DOMNodeList as we're modifying it further below
@@ -505,14 +505,14 @@ class AgaviXmlConfigParser
 				$attribute = $element->getAttributeNode('href');
 				$parts = explode('#', $attribute->nodeValue, 2);
 				$parts[0] = str_replace('\\', '/', AgaviToolkit::expandDirectives($parts[0]));
-				$attribute->nodeValue = implode('#', $parts);
+				$attribute->nodeValue = rawurlencode($parts[0]) . (isset($parts[1]) ? '#' . $parts[1] : '');
 				if(strpos($parts[0], '*') !== false || strpos($parts[0], '{') !== false) {
 					$glob = glob($parts[0], GLOB_BRACE | GLOB_NOSORT);
 					if($glob) {
 						$glob = array_unique($glob); // it could be that someone used /path/to/{Foo,*}/burp.xml so Foo would come before all others, that's why we need to remove duplicates as the * would match Foo again
 						foreach($glob as $path) {
 							$new = $element->cloneNode(true);
-							$new->setAttribute('href', $path . (isset($parts[1]) ? '#' . $parts[1] : ''));
+							$new->setAttribute('href', rawurlencode($path) . (isset($parts[1]) ? '#' . $parts[1] : ''));
 							$element->parentNode->insertBefore($new, $element);
 							++$i;
 						}

--- a/src/config/AgaviXmlConfigParser.class.php
+++ b/src/config/AgaviXmlConfigParser.class.php
@@ -495,7 +495,12 @@ class AgaviXmlConfigParser
 	public static function xinclude(AgaviXmlConfigDomDocument $document)
 	{
 		// replace %lala% directives in XInclude href attributes
-		foreach($document->getElementsByTagNameNS(self::NAMESPACE_XINCLUDE_2001, 'include') as $element) {
+		$elements = $document->getElementsByTagNameNS(self::NAMESPACE_XINCLUDE_2001, 'include');
+		$length = $elements->length;
+		// we can't foreach() over the DOMNodeList as we're modifying it further below
+		// see http://php.net/manual/en/class.domnodelist.php#83178
+		for($i = 0; $i < $length; $i++) {
+			$element = $elements->item($i);
 			if($element->hasAttribute('href')) {
 				$attribute = $element->getAttributeNode('href');
 				$parts = explode('#', $attribute->nodeValue, 2);
@@ -509,6 +514,7 @@ class AgaviXmlConfigParser
 							$new = $element->cloneNode(true);
 							$new->setAttribute('href', $path . (isset($parts[1]) ? '#' . $parts[1] : ''));
 							$element->parentNode->insertBefore($new, $element);
+							++$i;
 						}
 						$element->parentNode->removeChild($element);
 					}

--- a/test/sandbox/app/config/tests/xinclude/a.xml
+++ b/test/sandbox/app/config/tests/xinclude/a.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ae:configurations xmlns:ae="http://agavi.org/agavi/config/global/envelope/1.1">
+	<ae:configuration>
+		<Name>A</Name>
+	</ae:configuration>
+</ae:configurations>

--- a/test/sandbox/app/config/tests/xinclude/b.xml
+++ b/test/sandbox/app/config/tests/xinclude/b.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ae:configurations xmlns:ae="http://agavi.org/agavi/config/global/envelope/1.1">
+	<ae:configuration>
+		<Name>B</Name>
+	</ae:configuration>
+</ae:configurations>

--- a/test/sandbox/app/config/tests/xinclude/c &.xml
+++ b/test/sandbox/app/config/tests/xinclude/c &.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ae:configurations xmlns:ae="http://agavi.org/agavi/config/global/envelope/1.1">
+	<ae:configuration>
+		<Name>C</Name>
+	</ae:configuration>
+</ae:configurations>

--- a/test/sandbox/app/config/tests/xinclude_encoding.xml
+++ b/test/sandbox/app/config/tests/xinclude_encoding.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ae:configurations
+	xmlns:ae="http://agavi.org/agavi/config/global/envelope/1.1"
+	xmlns:xi="http://www.w3.org/2001/XInclude"
+>
+	<xi:include href="%core.config_dir%/tests/xinclude/c &amp;.xml" xpointer="xmlns(ae=http://agavi.org/agavi/config/global/envelope/1.1) xpointer(/ae:configurations/ae:configuration)" />
+</ae:configurations>

--- a/test/sandbox/app/config/tests/xinclude_glob_brace.xml
+++ b/test/sandbox/app/config/tests/xinclude_glob_brace.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ae:configurations
+	xmlns:ae="http://agavi.org/agavi/config/global/envelope/1.1"
+	xmlns:xi="http://www.w3.org/2001/XInclude"
+>
+	<xi:include href="%core.config_dir%/tests/xinclude/{a,b}.xml" xpointer="xmlns(ae=http://agavi.org/agavi/config/global/envelope/1.1) xpointer(/ae:configurations/ae:configuration)" />
+</ae:configurations>

--- a/test/sandbox/app/config/tests/xinclude_glob_simple.xml
+++ b/test/sandbox/app/config/tests/xinclude_glob_simple.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ae:configurations
+	xmlns:ae="http://agavi.org/agavi/config/global/envelope/1.1"
+	xmlns:xi="http://www.w3.org/2001/XInclude"
+>
+	<xi:include href="%core.config_dir%/tests/xinclude/*.xml" xpointer="xmlns(ae=http://agavi.org/agavi/config/global/envelope/1.1) xpointer(/ae:configurations/ae:configuration)" />
+</ae:configurations>

--- a/test/sandbox/app/config/tests/xinclude_simple.xml
+++ b/test/sandbox/app/config/tests/xinclude_simple.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ae:configurations
+	xmlns:ae="http://agavi.org/agavi/config/global/envelope/1.1"
+	xmlns:xi="http://www.w3.org/2001/XInclude"
+>
+	<xi:include href="%core.config_dir%/tests/xinclude/a.xml" xpointer="xmlns(ae=http://agavi.org/agavi/config/global/envelope/1.1) xpointer(/ae:configurations/ae:configuration)" />
+</ae:configurations>

--- a/test/tests/unit/config/AgaviXmlConfigHandlerTest.php
+++ b/test/tests/unit/config/AgaviXmlConfigHandlerTest.php
@@ -1,0 +1,53 @@
+<?php
+require_once(__DIR__ . '/ConfigHandlerTestBase.php');
+
+class AgaviXmlConfigHandlerTest extends ConfigHandlerTestBase
+{
+	public function testParseXincludeSimple()
+	{
+		$RACH = new AgaviReturnArrayConfigHandler();
+		$document = $this->parseConfiguration(AgaviConfig::get('core.config_dir') . '/tests/xinclude_simple.xml');
+		$actual = $this->includeCode($RACH->execute($document));
+		$expected = array(
+			'Name' => 'A',
+		);
+		$this->assertSame($expected, $actual);
+	}
+
+
+	public function testParseXincludeGlobSimple()
+	{
+		$RACH = new AgaviReturnArrayConfigHandler();
+		$document = $this->parseConfiguration(AgaviConfig::get('core.config_dir') . '/tests/xinclude_glob_simple.xml');
+		$actual = $this->includeCode($RACH->execute($document));
+		$expected = array(
+			'Name' => 'C',
+		);
+		$this->assertSame($expected, $actual);
+	}
+
+
+	public function testParseXincludeGlobBrace()
+	{
+		$RACH = new AgaviReturnArrayConfigHandler();
+		$document = $this->parseConfiguration(AgaviConfig::get('core.config_dir') . '/tests/xinclude_glob_brace.xml');
+		$actual = $this->includeCode($RACH->execute($document));
+		$expected = array(
+			'Name' => 'B',
+		);
+		$this->assertSame($expected, $actual);
+	}
+
+
+	public function testParseXincludeEncoding()
+	{
+		$RACH = new AgaviReturnArrayConfigHandler();
+		$document = $this->parseConfiguration(AgaviConfig::get('core.config_dir') . '/tests/xinclude_encoding.xml');
+		$actual = $this->includeCode($RACH->execute($document));
+		$expected = array(
+			'Name' => 'C',
+		);
+		$this->assertSame($expected, $actual);
+	}
+}
+?>


### PR DESCRIPTION
Fixes the whitespace issues with XIncludes outlined by [Agavi WTF](/agavi/agavi/wiki/WTF)