### PR TITLE
AgaviConfigHandler doesn't find handler for module.xml if path contains '..'

### DIFF
--- a/src/config/AgaviConfigCache.class.php
+++ b/src/config/AgaviConfigCache.class.php
@@ -78,7 +78,9 @@ class AgaviConfigCache
 	protected static function callHandler($name, $config, $cache, $context, array $handlerInfo = null)
 	{
 		self::setupHandlers();
-		
+
+		$name = realpath($name);
+
 		if(null === $handlerInfo) {
 			// we need to load the handlers first
 			$handlerInfo = self::getHandlerInfo($name);

--- a/test/tests/unit/config/AgaviConfigCacheTest.php
+++ b/test/tests/unit/config/AgaviConfigCacheTest.php
@@ -1,5 +1,13 @@
 <?php
 
+class TestAgaviConfigCacheTicket1574 extends AgaviConfigCache {
+
+	public static function test() {
+		$cfg = '/vagrant/agavi_/test/sandbox/app/../app/modules/Default/config/module.xml';
+		$cfg2 = '/vagrant/agavi_/test/sandbox/app/modules/Default/config/module.xml';
+		self::callHandler($cfg, $cfg2, AgaviConfigCache::getCacheName($cfg), 'test');
+	}
+}
 class AgaviConfigCacheTest extends AgaviPhpUnitTestCase
 {
 	/**
@@ -236,5 +244,10 @@ class AgaviConfigCacheTest extends AgaviPhpUnitTestCase
 		$config = AgaviConfig::get('core.module_dir').'/Default/config/config_handlers.xml';
 		AgaviTestingConfigCache::addConfigHandlersFile($config);
 		AgaviConfigCache::checkConfig(AgaviConfig::get('core.module_dir').'/Default/config/autoload.xml');
+	}
+
+	public function testTicket1573()
+	{
+		TestAgaviConfigCacheTicket1574::test();
 	}
 }


### PR DESCRIPTION
If the path to a module.xml-file contains '..' (which can happen in the wizard-generator-thing) AgaviConfigHandler::callHandler() doesn't find a handler for it. Running realpath() on the path before passing it to getHandlerInfo() fixes it.

References #1573