### PR TITLE
AgaviConfigCache can't find handler for files with '..' in the path

### DIFF
--- a/src/config/AgaviConfigCache.class.php
+++ b/src/config/AgaviConfigCache.class.php
@@ -78,7 +78,9 @@ class AgaviConfigCache
 	protected static function callHandler($name, $config, $cache, $context, array $handlerInfo = null)
 	{
 		self::setupHandlers();
-		
+
+		$name = realpath($name);
+
 		if(null === $handlerInfo) {
 			// we need to load the handlers first
 			$handlerInfo = self::getHandlerInfo($name);

--- a/src/config/AgaviConfigCache.class.php
+++ b/src/config/AgaviConfigCache.class.php
@@ -79,11 +79,9 @@ class AgaviConfigCache
 	{
 		self::setupHandlers();
 
-		$name = realpath($name);
-
 		if(null === $handlerInfo) {
 			// we need to load the handlers first
-			$handlerInfo = self::getHandlerInfo($name);
+			$handlerInfo = self::getHandlerInfo(realpath($name));
 		}
 
 		if($handlerInfo === null) {

--- a/test/tests/unit/config/AgaviConfigCacheTest.php
+++ b/test/tests/unit/config/AgaviConfigCacheTest.php
@@ -1,5 +1,13 @@
 <?php
 
+class TestAgaviConfigCacheTicket1574 extends AgaviConfigCache {
+
+	public static function test() {
+		$cfg = '/vagrant/agavi_/test/sandbox/app/../app/modules/Default/config/module.xml';
+		$cfg2 = '/vagrant/agavi_/test/sandbox/app/modules/Default/config/module.xml';
+		self::callHandler($cfg, $cfg2, AgaviConfigCache::getCacheName($cfg), 'test');
+	}
+}
 class AgaviConfigCacheTest extends AgaviPhpUnitTestCase
 {
 	/**
@@ -236,5 +244,10 @@ class AgaviConfigCacheTest extends AgaviPhpUnitTestCase
 		$config = AgaviConfig::get('core.module_dir').'/Default/config/config_handlers.xml';
 		AgaviTestingConfigCache::addConfigHandlersFile($config);
 		AgaviConfigCache::checkConfig(AgaviConfig::get('core.module_dir').'/Default/config/autoload.xml');
+	}
+
+	public function testTicket1573()
+	{
+		TestAgaviConfigCacheTicket1574::test();
 	}
 }

--- a/test/tests/unit/config/AgaviConfigCacheTest.php
+++ b/test/tests/unit/config/AgaviConfigCacheTest.php
@@ -3,8 +3,8 @@
 class TestAgaviConfigCacheTicket1574 extends AgaviConfigCache {
 
 	public static function test() {
-		$cfg = '/vagrant/agavi_/test/sandbox/app/../app/modules/Default/config/module.xml';
-		$cfg2 = '/vagrant/agavi_/test/sandbox/app/modules/Default/config/module.xml';
+		$cfg = str_replace('sandbox', 'sandbox/../sandbox', AgaviConfig::get('core.module_dir')).'/Default/config/module.xml';
+		$cfg2 = AgaviConfig::get('core.module_dir').'/Default/config/module.xml';
 		self::callHandler($cfg, $cfg2, AgaviConfigCache::getCacheName($cfg), 'test');
 	}
 }


### PR DESCRIPTION
AgaviConfigCache can't find the handler for a file if the ```%core.*_dir%```-part contains a '..'. This can happen easily for instance in the build system wizards. The PR wraps $name in ```AgaviConfigCache::callHandler()``` in a ```realpath()``` call to resolve the actual path.